### PR TITLE
add-majoolr-token

### DIFF
--- a/EIPS/eip-20-token-standard.md
+++ b/EIPS/eip-20-token-standard.md
@@ -176,6 +176,7 @@ Different implementations have been written by various teams that have different
 #### Example implementations are available at
 - https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/token/StandardToken.sol
 - https://github.com/ConsenSys/Tokens/blob/master/Token_Contracts/contracts/StandardToken.sol
+- https://github.com/Majoolr/ethereum-contracts/blob/master/TokenContract/StandardToken.sol
 
 #### Implementation of adding the force to 0 before calling "approve" again:
 - https://github.com/Giveth/minime/blob/master/contracts/MiniMeToken.sol


### PR DESCRIPTION
Our standard token implementation is an example of leveraging an on-chain library.
